### PR TITLE
Fix MK1 underbarrel having high toss

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1694,7 +1694,7 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/attached_gun/grenade/mk1/Initialize()
 	. = ..()
-	grenade_pass_flags = PASS_HIGH_OVER
+	grenade_pass_flags = NO_FLAGS
 
 //"ammo/flamethrower" is a bullet, but the actual process is handled through fire_attachment, linked through Fire().
 /obj/item/attachable/attached_gun/flamer


### PR DESCRIPTION
## About The Pull Request

Fixes MK1 having high toss, while it's supposed to have +2 grenades over the MK2 at the cost of IFF.

## Why It's Good For The Game

Fixes bug.

## Changelog

:cl:
fix: Fixed MK1 underslung grenade launcher having high toss when it shouldn't
/:cl:

